### PR TITLE
2022-2.3 envs

### DIFF
--- a/configs/config-py38.yml
+++ b/configs/config-py38.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-2.2-py38"
+env_name: "2022-2.3-py38"
 conda_env_file: "env-py38.yml"
 conda_binary: "mamba"
 python_version: "3.8"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-2.2
+    version: 2022-2.3
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-2.2-py39"
+env_name: "2022-2.3-py39"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-2.2
+    version: 2022-2.3
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py38.yml
+++ b/envs/env-py38.yml
@@ -1,4 +1,4 @@
-name: 2022-2.2-py38
+name: 2022-2.3-py38
 channels:
   - conda-forge
 dependencies:
@@ -26,7 +26,7 @@ dependencies:
   - conda-pack
   - csxtools
   - dask
-  - databroker >=1.2.5,<2
+  - databroker >=1.2.5,<2.0.0a
   - databroker-pack
   - dictdiffer
   - distributed

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2022-2.2-py39
+name: 2022-2.3-py39
 channels:
   - conda-forge
 dependencies:
@@ -27,7 +27,7 @@ dependencies:
   - conda-pack
   - csxtools
   - dask
-  - databroker >=1.2.5,<2
+  - databroker >=1.2.5,<2.0.0a
   - databroker-pack
   - dictdiffer
   - distributed


### PR DESCRIPTION
Fixing the wrong databroker version (v2.0.0b2 was still deployed while v1.2.5 was expected).

Fixes #4.