### PR TITLE
2022-3.2 env

### DIFF
--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,5 +1,5 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-3.1-py39"
+env_name: "2022-3.2-py39"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
@@ -21,7 +21,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-3.1
+    version: 2022-3.2
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -164,7 +164,7 @@ dependencies:
   - hklpy  # [linux]
   - hxnfly >=0.0.10
   - ppmac
-  - xpdacq >=1.1.0
+  - xpdacq >=1.1.2
   # Debugging tools:
   - hunter
   - logging_tree

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2022-3.1-py39
+name: 2022-3.2-py39
 channels:
   - conda-forge
 dependencies:
@@ -33,7 +33,7 @@ dependencies:
   - distributed
   - doi2bib
   - dpcmaps
-  # - edrixs
+  - edrixs
   - eiger-io
   - event-model >=1.18.0
   - fabio
@@ -84,7 +84,7 @@ dependencies:
   - openpyxl
   - ophyd >=1.7.0
   - papermill
-  - pdfstream >=0.6.0
+  - pdfstream >=0.6.1
   - peakutils
   - periodictable
   - photutils
@@ -140,8 +140,7 @@ dependencies:
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
-  # NOTE: shadow3 causes conflict issues with scipy>=1.8.
-  # - shadow3
+  - shadow3
   - srwpy
   - xrt
   #***************************************************************************#


### PR DESCRIPTION
### Updates
- pins `pdfstream` to v0.6.1 or newer (needed by PDF/XPD)
- uncomments `edrixs` and `shadow3` (both should be available in the conda-forge channel and compatible with latest `scipy`)
