### PR TITLE
2023-1.0 envs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10"]
       fail-fast: false
     env:
       TZ: America/New_York

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+default_language_version:
+    python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace

--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,14 +1,12 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-3.2-py310"
+env_name: "2023-1.0-py310"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
 pkg_name: ""
 pkg_version: ""
-# extra_packages: "nsls2-collection=2021C2.0=*_0 tmate mamba"
-extra_packages: "tmate mamba"
+extra_packages: "mamba"
 channels: "-c conda-forge"
-#extra_cmd_before_install: "yum install mesa-libGL mesa-libGL-devel -y"
 extra_cmd_before_install: "yum install mesa-libGL -y"
 extra_cmd_after_install: "conda remove perl --force -y"
 docker_upload:
@@ -21,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-3.2
+    version: 2023-1.0
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py39.yml
+++ b/configs/config-py39.yml
@@ -1,14 +1,12 @@
 docker_image: "nsls2/linux-anvil-cos7-x86_64:latest"
-env_name: "2022-3.2-py39"
+env_name: "2023-1.0-py39"
 conda_env_file: "env-py39.yml"
 conda_binary: "mamba"
 python_version: "3.9"
 pkg_name: ""
 pkg_version: ""
-# extra_packages: "nsls2-collection=2021C2.0=*_0 tmate mamba"
-extra_packages: "tmate mamba"
+extra_packages: "mamba"
 channels: "-c conda-forge"
-#extra_cmd_before_install: "yum install mesa-libGL mesa-libGL-devel -y"
 extra_cmd_before_install: "yum install mesa-libGL -y"
 extra_cmd_after_install: "conda remove perl --force -y"
 docker_upload:
@@ -21,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2022-3.2
+    version: 2023-1.0
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -127,7 +127,7 @@ dependencies:
   - suitcase-utils
   - sympy
   - toml
-  - tomopy >=1.11
+  - tomopy >=1.12.2
   - tornado
   - tqdm
   - tzlocal !=3.0

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -95,6 +95,8 @@ dependencies:
   - pyepics >=3.4.2
   - pyfai
   - pyfftw
+  - pymca
+  - pymcr
   - pymongo >=3.7
   - pypdf2
   - pyqt >=5.12.0

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -170,3 +170,6 @@ dependencies:
   - line_profiler
   - pyinstrument
   - pyperformance
+  # ML:
+  - gpytorch
+  - pytorch

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -77,7 +77,7 @@ dependencies:
   - nsls2-detector-handlers >=0.0.2
   - nslsii >=0.8.0
   - numexpr
-  - numpy >=1.24.0
+  - numpy >=1.20
   - nyxtools >=0.0.10
   - oct2py
   - opencv
@@ -112,7 +112,7 @@ dependencies:
   - sasview
   - scikit-beam >=0.0.24
   - scikit-learn
-  - scipy >=1.9.0
+  - scipy >=1.9
   - silx
   - sixtools
   - slackclient

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2022-3.2-py310
+name: 2023-1.0-py310
 channels:
   - conda-forge
 dependencies:
@@ -14,13 +14,13 @@ dependencies:
   - arvpyf
   - attrs >=18.0
   - black
-  - bluesky >=1.9.0
+  - bluesky >=1.10.0
   - bluesky-kafka >=0.9.1  # [not win]
   - bluesky-live >=0.0.8
-  - bluesky-queueserver >=0.0.16
+  - bluesky-queueserver >=0.0.18
   # TODO: sort out conflicts with bluesky-queueserver-api
   # - bluesky-queueserver-api
-  - bluesky-widgets >=0.0.13
+  - bluesky-widgets >=0.0.14
   - boto3
   - chxtools
   - cmasher
@@ -35,7 +35,7 @@ dependencies:
   - dpcmaps
   - edrixs
   - eiger-io
-  - event-model >=1.18.0
+  - event-model >=1.19.1
   - fabio
   - ffmpeg >=4.0
   - flake8
@@ -64,27 +64,27 @@ dependencies:
   - lixtools
   - lmfit
   - lxml
-  - matplotlib >=3.1.0,!=3.3
+  - matplotlib >=3.6.2
   - memory_profiler
   - mendeleev
   - modestimage
-  - mxtools >=0.0.6
-  - napari >=0.4.11
+  - mxtools >=0.0.8
+  - napari >=0.4.17
   - natsort
   - netcdf4
-  - nexpy >=0.14.1
+  - nexpy >=0.14.8
   - nodejs
   - nsls2-detector-handlers >=0.0.2
-  - nslsii >=0.7.0
+  - nslsii >=0.8.0
   - numexpr
-  - numpy >=1.14.0
+  - numpy >=1.24.0
   - nyxtools >=0.0.10
   - oct2py
   - opencv
   - openpyxl
   - ophyd >=1.7.0
   - papermill
-  - pdfstream >=0.6.1=*_2
+  - pdfstream >=0.6.2
   - peakutils
   - periodictable
   - photutils
@@ -98,21 +98,21 @@ dependencies:
   - pyfftw
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.9.0
+  - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
   - python
   - python-graphviz
-  - pyxrf >=1.0.18
+  - pyxrf >=1.0.21
   - pyzbar  # [not win]
-  - qt >=5.9.0
+  - qt >=5.12.0
   - redis-py
   - reportlab
   - requests
   - sasview
   - scikit-beam >=0.0.24
   - scikit-learn
-  - scipy >=1.8.0
+  - scipy >=1.9.0
   - silx
   - sixtools
   - slackclient
@@ -134,9 +134,8 @@ dependencies:
   - xlrd
   - xlwt
   - xmidas >=0.1.2
-  - xpdan >=0.8.2
   - xray-vision >=0.1.1
-  - xraylarch >=0.9.58
+  - xraylarch >=0.9.60
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
@@ -164,7 +163,7 @@ dependencies:
   - hklpy  # [linux]
   - hxnfly >=0.0.10
   - ppmac
-  - xpdacq >=1.1.2
+  - xpdacq >=1.1.4
   # Debugging tools:
   - hunter
   - logging_tree
@@ -174,4 +173,5 @@ dependencies:
   - pyperformance
   - pip
   - pip:
+    # TODO: check if it is compatible via a conda package now.
     - bluesky-queueserver-api

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -18,8 +18,7 @@ dependencies:
   - bluesky-kafka >=0.9.1  # [not win]
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
-  # TODO: sort out conflicts with bluesky-queueserver-api
-  # - bluesky-queueserver-api
+  - bluesky-queueserver-api >=0.0.9
   - bluesky-widgets >=0.0.14
   - boto3
   - chxtools
@@ -171,7 +170,3 @@ dependencies:
   - line_profiler
   - pyinstrument
   - pyperformance
-  - pip
-  - pip:
-    # TODO: check if it is compatible via a conda package now.
-    - bluesky-queueserver-api

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -15,7 +15,7 @@ dependencies:
   - attrs >=18.0
   - black
   - bluesky >=1.10.0
-  - bluesky-kafka >=0.9.1  # [not win]
+  - bluesky-kafka >=0.9.1
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
   - bluesky-queueserver-api >=0.0.9
@@ -91,7 +91,7 @@ dependencies:
   - pocl  # needed by pyopencl, used by the `xrt` package
   - prefect
   - py4xs
-  - pycentroids  # [not win]
+  - pycentroids
   - pyepics >=3.4.2
   - pyfai
   - pyfftw
@@ -103,7 +103,7 @@ dependencies:
   - python
   - python-graphviz
   - pyxrf >=1.0.21
-  - pyzbar  # [not win]
+  - pyzbar
   - qt >=5.12.0
   - redis-py
   - reportlab
@@ -154,7 +154,7 @@ dependencies:
   # - pydm
   - pyolog >=4.5.0
   - pyserial
-  - python-confluent-kafka  # [not win]
+  - python-confluent-kafka
   - pyzenodo3
   - simple-pid
   - slack-sdk

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -127,7 +127,7 @@ dependencies:
   - suitcase-utils
   - sympy
   - toml
-  - tomopy >=1.11
+  - tomopy >=1.12.2
   - tornado
   - tqdm
   - tzlocal !=3.0

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -95,6 +95,8 @@ dependencies:
   - pyepics >=3.4.2
   - pyfai
   - pyfftw
+  - pymca
+  - pymcr
   - pymongo >=3.7
   - pypdf2
   - pyqt >=5.12.0

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -170,3 +170,6 @@ dependencies:
   - line_profiler
   - pyinstrument
   - pyperformance
+  # ML:
+  - gpytorch
+  - pytorch

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -1,4 +1,4 @@
-name: 2022-3.2-py39
+name: 2023-1.0-py39
 channels:
   - conda-forge
 dependencies:
@@ -14,13 +14,13 @@ dependencies:
   - arvpyf
   - attrs >=18.0
   - black
-  - bluesky >=1.9.0
+  - bluesky >=1.10.0
   - bluesky-kafka >=0.9.1  # [not win]
   - bluesky-live >=0.0.8
-  - bluesky-queueserver >=0.0.16
+  - bluesky-queueserver >=0.0.18
   # TODO: sort out conflicts with bluesky-queueserver-api
   # - bluesky-queueserver-api
-  - bluesky-widgets >=0.0.13
+  - bluesky-widgets >=0.0.14
   - boto3
   - chxtools
   - cmasher
@@ -35,7 +35,7 @@ dependencies:
   - dpcmaps
   - edrixs
   - eiger-io
-  - event-model >=1.18.0
+  - event-model >=1.19.1
   - fabio
   - ffmpeg >=4.0
   - flake8
@@ -64,27 +64,27 @@ dependencies:
   - lixtools
   - lmfit
   - lxml
-  - matplotlib >=3.1.0,!=3.3
+  - matplotlib >=3.6.2
   - memory_profiler
   - mendeleev
   - modestimage
-  - mxtools >=0.0.6
-  - napari >=0.4.11
+  - mxtools >=0.0.8
+  - napari >=0.4.17
   - natsort
   - netcdf4
-  - nexpy >=0.14.1
+  - nexpy >=0.14.8
   - nodejs
   - nsls2-detector-handlers >=0.0.2
-  - nslsii >=0.7.0
+  - nslsii >=0.8.0
   - numexpr
-  - numpy >=1.14.0
+  - numpy >=1.24.0
   - nyxtools >=0.0.10
   - oct2py
   - opencv
   - openpyxl
   - ophyd >=1.7.0
   - papermill
-  - pdfstream >=0.6.1
+  - pdfstream >=0.6.2
   - peakutils
   - periodictable
   - photutils
@@ -98,21 +98,21 @@ dependencies:
   - pyfftw
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.9.0
+  - pyqt >=5.12.0
   - pyqtgraph
   - pystackreg
   - python
   - python-graphviz
-  - pyxrf >=1.0.18
+  - pyxrf >=1.0.21
   - pyzbar  # [not win]
-  - qt >=5.9.0
+  - qt >=5.12.0
   - redis-py
   - reportlab
   - requests
   - sasview
   - scikit-beam >=0.0.24
   - scikit-learn
-  - scipy >=1.8.0
+  - scipy >=1.9.0
   - silx
   - sixtools
   - slackclient
@@ -134,9 +134,8 @@ dependencies:
   - xlrd
   - xlwt
   - xmidas >=0.1.2
-  - xpdan >=0.8.2
   - xray-vision >=0.1.1
-  - xraylarch >=0.9.58
+  - xraylarch >=0.9.60
   - zbar  # dependency of pyzbar
   # Simulation packages:
   - oscars
@@ -164,7 +163,7 @@ dependencies:
   - hklpy  # [linux]
   - hxnfly >=0.0.10
   - ppmac
-  - xpdacq >=1.1.2
+  - xpdacq >=1.1.4
   # Debugging tools:
   - hunter
   - logging_tree
@@ -174,4 +173,5 @@ dependencies:
   - pyperformance
   - pip
   - pip:
+    # TODO: check if it is compatible via a conda package now.
     - bluesky-queueserver-api

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -77,7 +77,7 @@ dependencies:
   - nsls2-detector-handlers >=0.0.2
   - nslsii >=0.8.0
   - numexpr
-  - numpy >=1.24.0
+  - numpy >=1.20
   - nyxtools >=0.0.10
   - oct2py
   - opencv
@@ -112,7 +112,7 @@ dependencies:
   - sasview
   - scikit-beam >=0.0.24
   - scikit-learn
-  - scipy >=1.9.0
+  - scipy >=1.9
   - silx
   - sixtools
   - slackclient

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -18,8 +18,7 @@ dependencies:
   - bluesky-kafka >=0.9.1  # [not win]
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
-  # TODO: sort out conflicts with bluesky-queueserver-api
-  # - bluesky-queueserver-api
+  - bluesky-queueserver-api >=0.0.9
   - bluesky-widgets >=0.0.14
   - boto3
   - chxtools
@@ -171,7 +170,3 @@ dependencies:
   - line_profiler
   - pyinstrument
   - pyperformance
-  - pip
-  - pip:
-    # TODO: check if it is compatible via a conda package now.
-    - bluesky-queueserver-api

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -15,7 +15,7 @@ dependencies:
   - attrs >=18.0
   - black
   - bluesky >=1.10.0
-  - bluesky-kafka >=0.9.1  # [not win]
+  - bluesky-kafka >=0.9.1
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.18
   - bluesky-queueserver-api >=0.0.9
@@ -91,7 +91,7 @@ dependencies:
   - pocl  # needed by pyopencl, used by the `xrt` package
   - prefect
   - py4xs
-  - pycentroids  # [not win]
+  - pycentroids
   - pyepics >=3.4.2
   - pyfai
   - pyfftw
@@ -103,7 +103,7 @@ dependencies:
   - python
   - python-graphviz
   - pyxrf >=1.0.21
-  - pyzbar  # [not win]
+  - pyzbar
   - qt >=5.12.0
   - redis-py
   - reportlab
@@ -154,7 +154,7 @@ dependencies:
   # - pydm
   - pyolog >=4.5.0
   - pyserial
-  - python-confluent-kafka  # [not win]
+  - python-confluent-kafka
   - pyzenodo3
   - simple-pid
   - slack-sdk


### PR DESCRIPTION
The environments are to be deployed during the January 2023 shutdown.

Diffs:

```diff
$ diff envs/env-py39.yml envs/env-py310.yml
1c1
< name: 2023-1.0-py39
---
> name: 2023-1.0-py310
10c10
<   - python >=3.9,<3.10
---
>   - python >=3.10,<3.11
```

```diff
$ diff configs/config-py39.yml configs/config-py310.yml
2,3c2,3
< env_name: "2023-1.0-py39"
< conda_env_file: "env-py39.yml"
---
> env_name: "2023-1.0-py310"
> conda_env_file: "env-py310.yml"
5c5
< python_version: "3.9"
---
> python_version: "3.10"
```