### PR TITLE
add digautoprofiler package to environments

### DIFF
--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -183,3 +183,6 @@ dependencies:
   - gpytorch
   - ortools-python
   - pytorch
+  - pip 
+  - pip:
+    - digautoprofiler

--- a/envs/env-py39.yml
+++ b/envs/env-py39.yml
@@ -183,3 +183,6 @@ dependencies:
   - gpytorch
   - ortools-python
   - pytorch
+  - pip 
+  - pip:
+    - digautoprofiler


### PR DESCRIPTION
Hi,

We would like to add the digautoprofiler library to the jupyterhub.

This adds a jupyterlab extension, AutoProfiler, that helps users visualize their data with an interactive visualization sidebar. More information is in our github: https://github.com/cmudig/AutoProfiler

I am the developer of this package and would be happy to answer any questions about it (email: [willepp@cmu.edu](mailto:willepp@cmu.edu)). Our group at CMU has been working with Wei Xu at BNL on this project.