### PR TITLE
2023-3.0 py310 env

### DIFF
--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-2.1-py310"
+env_name: "2023-3.0-py310"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-2.1
+    version: 2023-3.0
     creators:
       - name: Rakitin, Maksim
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -115,7 +115,7 @@ dependencies:
   - pyqtgraph
   - pystackreg
   - python-graphviz
-  - pyxrf >=1.0.23
+  - pyxrf >=1.0.24
   - pyzbar
   - qt >=5.15.0
   - redis-py

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-2.1-py310
+name: 2023-3.0-py310
 channels:
   - conda-forge
 dependencies:
@@ -15,7 +15,7 @@ dependencies:
   - attrs >=18.0
   - awkward
   - black
-  - bluesky >=1.11.0
+  - bluesky ==1.10.0
   - bluesky-adaptive >=0.3.1
   - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
@@ -48,6 +48,7 @@ dependencies:
   - h5py !=3.4
   - hdf5-external-filter-plugins-bitshuffle
   - hdf5-external-filter-plugins-lz4
+  - historydict
   - hxntools >=0.6.1
   - igor
   - imageio
@@ -98,6 +99,7 @@ dependencies:
   - photutils
   - pillow
   - pocl  # needed by pyopencl, used by the `xrt` package
+  - pre-commit
   - prefect
   - py4xs
   - pycentroids
@@ -109,17 +111,17 @@ dependencies:
   - pymcr
   - pymongo >=3.7
   - pypdf2
-  - pyqt >=5.12.0
+  - pyqt >=5.15.0
   - pyqtgraph
   - pystackreg
   - python-graphviz
   - pyxrf >=1.0.23
   - pyzbar
-  - qt >=5.12.0
+  - qt >=5.15.0
   - redis-py
   - reportlab
   - requests
-  - sasview
+  # - sasview  # does not work with pyqt>=5.15
   - scikit-beam >=0.0.24
   - scikit-learn
   - scipy >=1.9
@@ -153,6 +155,7 @@ dependencies:
   - srwpy >=4.0.0b1
   - sirepo-bluesky >=0.6.2
   - xrt
+  - zict <3.0.0
   #***************************************************************************#
   #                                                                           #
   #            Dependencies from the `nsls2-collection` metapackage           #
@@ -190,3 +193,4 @@ dependencies:
   - gpytorch
   - ortools-python
   - pytorch
+  - scikit-optimize


### PR DESCRIPTION
Use pyqt/qt v5.15 to make the latest pyFAI work.
Also, add the dependencies listed in https://github.com/nsls2-conda-envs/nsls2-collection-tiled/issues/18.