### PR TITLE
2023-3.2 env

### DIFF
--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-3.1-py310"
+env_name: "2023-3.2-py310"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,9 +19,9 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-3.1
+    version: 2023-3.2
     creators:
-      - name: Rakitin, Maksim
+      - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"
       - name: Bischof, Garrett
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-3.1-py310
+name: 2023-3.2-py310
 channels:
   - conda-forge
 dependencies:
@@ -8,6 +8,7 @@ dependencies:
   #                                                                           #
   #***************************************************************************#
   - python >=3.10,<3.11
+  - algotom
   - amostra <=1.0
   - ansiwrap
   - area-detector-handlers >=0.0.9
@@ -39,10 +40,11 @@ dependencies:
   - databroker >=1.2.5,<2.0.0a
   - databroker-pack
   - dictdiffer
+  - discorpy
   - distributed
   - doi2bib
   - dpcmaps
-  - edrixs
+  # - edrixs  # conflicts caused by the latest numexpr, to resolve later.
   - eiger-io
   - event-model >=1.19.2
   - fabio
@@ -87,7 +89,7 @@ dependencies:
   - nodejs
   - nsls2-detector-handlers >=0.0.3
   - nslsii >=0.9.1
-  - numexpr
+  - numexpr >=2.8.0
   - numpy >=1.20
   - nyxtools >=0.0.12
   - oct2py
@@ -101,7 +103,7 @@ dependencies:
   - pytables  # used by pandas .to_hdf()
   # end of pandas deps
   - papermill
-  - pdfstream >=0.6.2
+  - pdfstream ==0.5.2  # same as in the 2022-2.0-py37 env, https://zenodo.org/records/6462525/files/2022-2.0-py37.yml
   - peakutils
   - periodictable
   - photutils
@@ -140,6 +142,7 @@ dependencies:
   - sixtools
   - slackclient
   - smi-analysis
+  - sqlalchemy >=2.0.20
   - suitcase-csv
   - suitcase-json-metadata
   - suitcase-jsonl
@@ -194,7 +197,7 @@ dependencies:
   - kkcalc
   - ppmac
   - pychx >=4.1.2
-  - xpdacq >=1.1.4
+  - xpdacq ==1.0.0
   # Debugging tools:
   - hunter
   - logging_tree


### PR DESCRIPTION
Mirror changes from https://github.com/nsls2-conda-envs/nsls2-collection-tiled/pull/24.

```diff
$ diff nsls2-collection/configs/config-py310.yml nsls2-collection-tiled/configs/config-py310.yml
2c2
< env_name: "2023-3.2-py310"
---
> env_name: "2023-3.2-py310-tiled"
22c22
<     version: 2023-3.2
---
>     version: 2023-3.2-tiled
```

```diff
$ diff nsls2-collection/envs/env-py310.yml nsls2-collection-tiled/envs/env-py310.yml
1c1
< name: 2023-3.2-py310
---
> name: 2023-3.2-py310-tiled
40,41c40
<   - databroker >=1.2.5,<2.0.0a
<   - databroker-pack
---
>   - databroker >=2.0.0b30
65d63
<   - intake <=0.6.4
154a153
>   - tiled >=0.1.0a106
```