### PR TITLE
2024-1.0 envs

### DIFF
--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-3.3-py310"
+env_name: "2024-1.0-py310"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-3.3
+    version: 2024-1.0
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py311.yml
+++ b/configs/config-py311.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2023-3.3-py311"
+env_name: "2024-1.0-py311"
 conda_env_file: "env-py311.yml"
 conda_binary: "mamba"
 python_version: "3.11"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2023-3.3
+    version: 2024-1.0
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2023-3.3-py310
+name: 2024-1.0-py310
 channels:
   - conda-forge
 dependencies:
@@ -26,6 +26,7 @@ dependencies:
   - bokeh
   - boto3
   - bottleneck
+  - broh5
   - chxtools
   - cmasher
   - conda-pack
@@ -73,6 +74,7 @@ dependencies:
   - jedi
   - jupyter
   - jupyterlab
+  - ldap3
   - legacy-suitcase
   - lixtools
   - lmfit
@@ -99,7 +101,7 @@ dependencies:
   # pandas and deps
   - pandas
   - openpyxl  # used by pandas .to_excel()
-  - pyarrow  # used by pandas .to_parquet()
+  - pyarrow  # >=14.0.1  # used by pandas .to_parquet()
   - pytables  # used by pandas .to_hdf()
   # end of pandas deps
   - papermill
@@ -130,6 +132,7 @@ dependencies:
   - pyxrf >=1.0.24
   - pyzbar
   - qt >=5.15.0
+  - redis-dict
   - redis-py
   - reportlab
   - requests

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -1,4 +1,4 @@
-name: 2023-3.3-py311
+name: 2024-1.0-py311
 channels:
   - conda-forge
 dependencies:
@@ -26,6 +26,7 @@ dependencies:
   - bokeh
   - boto3
   - bottleneck
+  - broh5
   - chxtools
   - cmasher
   - conda-pack
@@ -73,6 +74,7 @@ dependencies:
   - jedi
   - jupyter
   - jupyterlab
+  - ldap3
   - legacy-suitcase
   - lixtools
   - lmfit
@@ -99,7 +101,7 @@ dependencies:
   # pandas and deps
   - pandas
   - openpyxl  # used by pandas .to_excel()
-  - pyarrow  # used by pandas .to_parquet()
+  - pyarrow  # >=14.0.1  # used by pandas .to_parquet()
   - pytables  # used by pandas .to_hdf()
   # end of pandas deps
   - papermill
@@ -130,6 +132,7 @@ dependencies:
   - pyxrf >=1.0.24
   - pyzbar
   - qt >=5.15.0
+  - redis-dict
   - redis-py
   - reportlab
   - requests


### PR DESCRIPTION
Mirroring changes from https://github.com/nsls2-conda-envs/nsls2-collection-tiled/pull/28.

```diff
$ diff nsls2-collection/envs/env-py310.yml nsls2-collection-tiled/envs/env-py310.yml
1c1
< name: 2024-1.0-py310
---
> name: 2024-1.0-py310-tiled
41,42c41
<   - databroker >=1.2.5,<2.0.0a
<   - databroker-pack
---
>   - databroker >=2.0.0b33
66d64
<   - intake <=0.6.4
157a156
>   - tiled >=0.1.0a113
```

```diff
$ diff nsls2-collection/envs/env-py311.yml nsls2-collection-tiled/envs/env-py311.yml
1c1
< name: 2024-1.0-py311
---
> name: 2024-1.0-py311-tiled
41,42c41
<   - databroker >=1.2.5,<2.0.0a
<   - databroker-pack
---
>   - databroker >=2.0.0b33
66d64
<   - intake <=0.6.4
157a156
>   - tiled >=0.1.0a113
```

```diff
❯ diff nsls2-collection/envs/env-py310.yml nsls2-collection/envs/env-py311.yml
1c1
< name: 2024-1.0-py310
---
> name: 2024-1.0-py311
10c10
<   - python >=3.10,<3.11
---
>   - python >=3.11,<3.12
```